### PR TITLE
Use Eval to prevent StackOverFlows

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,10 +6,16 @@ plugins {
 repositories {
     mavenLocal()
     mavenCentral()
+    maven {
+        url = uri("https://oss.jfrog.org/artifactory/oss-snapshot-local/")
+        content {
+            includeGroup("io.arrow-kt")
+        }
+    }
 }
 
 dependencies {
-    val arrowVersion = "0.10.4"
+    val arrowVersion = "0.10.5-SNAPSHOT"
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("io.arrow-kt:arrow-core:$arrowVersion")

--- a/src/main/kotlin/io/github/kartoffelsup/json/JsonParser.kt
+++ b/src/main/kotlin/io/github/kartoffelsup/json/JsonParser.kt
@@ -1,189 +1,184 @@
 package io.github.kartoffelsup.json
 
 import arrow.Kind
-import arrow.core.ForListK
-import arrow.core.None
-import arrow.core.Option
+import arrow.core.AndThen
+import arrow.core.ListK
 import arrow.core.SequenceK
-import arrow.core.Some
 import arrow.core.Tuple2
-import arrow.core.extensions.fx
-import arrow.core.extensions.list.traverse.sequence
-import arrow.core.fix
 import arrow.core.k
 import arrow.core.toMap
-import arrow.core.toOption
 import arrow.core.toT
 import kotlin.time.ExperimentalTime
 import kotlin.time.TimedValue
 import kotlin.time.measureTimedValue
 
-interface Parser<out A> : ParserOf<A> {
+interface Parser<A> : ParserOf<A> {
     // TODO: no proper error reporting
-    val runParser: (StringView) -> Option<Tuple2<StringView, A>>
+    val runParser: AndThen<StringView, Tuple2<StringView, A>?>
 
-    fun <B> map(f: (A) -> B): Parser<B> =
-        Parser { input: StringView ->
-            runParser(input).map { t ->
-                t.map(f)
+    fun <B> map(f: (A) -> B): Parser<B> = Parser(
+        runParser.map { it?.map { t -> f(t) } }
+    )
+
+    fun <B> ap(ff: ParserOf<(A) -> B>): Parser<B> = lazyAp { ff }
+
+    fun <B> lazyAp(ff: () -> ParserOf<(A) -> B>): Parser<B> = Parser(
+        fix().runParser.map { op: Tuple2<StringView, A>? ->
+            op?.let { (input: StringView, a: A) ->
+                ff().fix().runParser(input)?.let { (out: StringView, f: (A) -> B) ->
+                    out toT f(a)
+                }
             }
-        }
-
-    fun <B> ap(ff: ParserOf<(A) -> B>): Parser<B> = Parser { input ->
-        Option.fx {
-            val (input2: StringView, f: (A) -> B) = ff.fix().runParser(input).bind()
-            val (input3: StringView, g: A) = fix().runParser(input2).bind()
-            Tuple2(input3, f(g))
-        }
-    }
+        })
 
     companion object {
-        operator fun <T> invoke(parser: (StringView) -> Option<Tuple2<StringView, T>>): Parser<T> =
+        operator fun <A> invoke(parser: (StringView) -> Tuple2<StringView, A>?): Parser<A> =
+            ParserInstance(AndThen(parser))
+
+        operator fun <A> invoke(parser: AndThen<StringView, Tuple2<StringView, A>?>): Parser<A> =
             ParserInstance(parser)
 
-        fun <A> just(a: A): Parser<A> = Parser { input ->
-            Some(Tuple2(input, a))
-        }
+        fun <A> just(a: A): Parser<A> = Parser { input: StringView -> Tuple2(input, a) }
 
         private data class ParserInstance<A>(
-            override val runParser: (StringView) -> Option<Tuple2<StringView, A>>
+            override val runParser: AndThen<StringView, Tuple2<StringView, A>?>
         ) : Parser<A>
     }
 }
 
-internal fun maybe(char: Char): Parser<Option<Char>> =
+internal fun maybe(char: Char): Parser<Char?> =
     ParserAlternativeInstance.run {
         val maybeParser: Kind<ForParser, String> = stringParser(char.toString()) alt just("")
-        maybeParser.map { it.firstOrNull().toOption() }
+        maybeParser.map { it.firstOrNull() }
     }.fix()
 
 internal fun charParser(char: Char): Parser<Char> =
-    Parser { input: StringView ->
+    Parser(AndThen { input: StringView ->
         input
             .takeIf { it.isNotEmpty() && it[0] == char }
-            .toOption()
-            .map { it.drop(1) toT it[0] }
-    }
+            ?.let { it.drop(1) toT it[0] }
+    })
 
-internal fun stringParser(string: String): Parser<String> {
-    val parser: Parser<Kind<ForListK, Char>> = string
+internal fun stringParser(toParse: String): Parser<String> {
+    val parser: Parser<ListK<Char>> = toParse
         .map(::charParser).k()
-        .sequence(ParserApplicativeInstance).fix()
+        .traverse(ParserApplicativeInstance) { it.fix() }.fix()
 
-    return parser.map { it.fix().s() }
+    return parser.map { it.s() }
 }
 
-internal fun spanParser(p: (Char) -> Boolean): Parser<StringView> = Parser { input ->
-    val (xs, input2) = input.span(p)
-    Some(input2 toT xs)
-}
+internal fun spanParser(p: (Char) -> Boolean): Parser<StringView> =
+    Parser(AndThen { input ->
+        val (xs, input2) = input.span(p)
+        input2 toT xs
+    })
 
-fun jsonNull(): Parser<JsonValue> =
-    stringParser("null").map { JsonNull }
-
-fun jsonBool(): Parser<JsonValue> = ParserAlternativeInstance.run {
-    stringParser("true").map { JsonBool(true) } alt stringParser("false").map { JsonBool(false) }
-}.fix()
-
-fun notEmpty(p: Parser<StringView>): Parser<StringView> = Parser { input ->
-    val runParser = p.runParser(input)
-    runParser.flatMap { tuple ->
-        if (tuple.b.isEmpty()) {
-            None
-        } else {
-            Some(tuple)
-        }
+val jsonNull: Parser<JsonValue> =
+    ParserFunctorInstance.run {
+        stringParser("null").mapConst(JsonNull).fix()
     }
-}
 
-fun jsonNumber(): Parser<JsonValue> {
-    val maybeMinusCombineWithDigits: Parser<(StringView) -> String> = maybe('-')
-        .map { maybeMinus: Option<Char> ->
-            { digits: StringView ->
-                maybeMinus.fold(
-                    ifEmpty = { digits.value },
-                    ifSome = { minus -> minus + digits.value }
-                )
-            }
+val jsonBool: Parser<JsonValue> =
+    ParserAlternativeInstance.run {
+        val jsonTrue = stringParser("true").mapConst(JsonBool(true))
+        val jsonFalse = stringParser("false").mapConst(JsonBool(false))
+        jsonTrue.alt(jsonFalse).fix()
+    }
+
+fun notEmpty(p: Parser<StringView>): Parser<StringView> =
+    Parser(
+        p.runParser.andThen { option: Tuple2<StringView, StringView>? ->
+            option?.takeIf { it.b.isNotEmpty() }
         }
+    )
 
-    return notEmpty(spanParser(Char::isDigit)).ap(maybeMinusCombineWithDigits).map { JsonNumber(it.toInt()) }
-}
+val jsonNumber: Parser<JsonValue> = maybe('-').ap(notEmpty(spanParser(Char::isDigit))
+    .map { digits: StringView ->
+        { maybeMinus: Char? ->
+            maybeMinus?.let { minus -> minus + digits.value } ?: digits.value
+        }
+    }).map { JsonNumber(it.toInt()) }
 
 // TODO: no escape support
-fun stringLiteral(): Parser<StringView> = ParserAlternativeInstance.run {
-    charParser('"').followedBy(spanParser { it != '"' }.apTap(charParser('"'))).fix()
-}
-
-fun jsonString(): Parser<JsonValue> = ParserAlternativeInstance.run {
-    stringLiteral().map { JsonString(it.value) }
-}
-
-fun whiteSpace(): Parser<StringView> = spanParser { it.isWhitespace() }
-
-fun <A, B> sepBy(sep: Parser<A>, element: Parser<B>): Parser<List<B>> = ParserAlternativeInstance.run {
-    val elementAsSeq: Parser<SequenceK<B>> = element.map { sequenceOf(it).k() }
-    val rw: Parser<SequenceK<B>> = sep.followedBy(element).many().fix()
-
-    val cons: Parser<(SequenceK<B>) -> SequenceK<B>> =
-        elementAsSeq.map { a: SequenceK<B> -> { b: SequenceK<B> -> (a + b).k() } }
-
-    val result: Parser<SequenceK<B>> = rw.ap(cons).fix()
-    val emptySequence: Parser<SequenceK<B>> = just(emptySequence<B>().k()).fix()
-    (result alt emptySequence).map { it.toList() }.fix()
-}
-
-fun jsonArray(): Parser<JsonValue> = ParserAlternativeInstance.run {
-    val separator = whiteSpace().followedBy(charParser(',')).apTap(whiteSpace()).fix()
-    val elements: Parser<List<JsonValue>> = sepBy(separator, jsonValue())
-    val prefix = charParser('[').followedBy(whiteSpace())
-    val suffix = whiteSpace().apTap(charParser(']'))
-    val result: Parser<List<JsonValue>> = prefix.followedBy(elements).apTap(suffix).fix()
-    result.map { JsonArray(it) }
-}
-
-fun jsonObject(): Parser<JsonValue> = ParserAlternativeInstance.run {
-    val prefix = charParser('{').apTap(whiteSpace()).fix()
-    val suffix = whiteSpace().followedBy(charParser('}')).fix()
-    val objectSeparator = whiteSpace().followedBy(charParser(',')).apTap(whiteSpace()).fix()
-    val keyValueSeparator: Parser<Char> = whiteSpace().followedBy(charParser(':')).apTap(whiteSpace()).fix()
-    val combineIntoObject: (StringView, Char, JsonValue) -> Tuple2<String, JsonValue> =
-        { key, _, value -> key.value toT value }
-
-    val map: Parser<(Char) -> (JsonValue) -> Tuple2<String, JsonValue>> =
-        stringLiteral().map { s: StringView -> { c: Char -> { v: JsonValue -> combineIntoObject(s, c, v) } } }
-
-    val pair: Parser<Tuple2<String, JsonValue>> = jsonValue().ap(keyValueSeparator.ap(map))
-
-    prefix.followedBy(sepBy(objectSeparator, pair)).apTap(suffix).fix()
-        .map { JsonObject(it.toMap()) }
-}
-
-fun jsonValue(): Parser<JsonValue> = Parser { input: StringView ->
+val stringLiteral: Parser<StringView> =
     ParserAlternativeInstance.run {
-        jsonNull() alt jsonBool() alt jsonNumber() alt jsonString() alt jsonArray() alt jsonObject()
-    }.fix().runParser(input)
-}
+        charParser('"').followedBy(spanParser { it != '"' }.apTap(charParser('"'))).fix()
+    }
+
+val jsonString: Parser<JsonValue> =
+    ParserAlternativeInstance.run {
+        stringLiteral.map { JsonString(it.value) }
+    }
+
+val whiteSpace: Parser<StringView> = spanParser { it.isWhitespace() }
+
+fun <A, B> sepBy(sep: Parser<A>, element: Parser<B>): Parser<List<B>> =
+    ParserAlternativeInstance.run {
+        val elementAsSeq: Parser<SequenceK<B>> = element.map { sequenceOf(it).k() }
+        val manySeparatedElements: Parser<SequenceK<B>> = sep.followedBy(element).many().fix()
+
+        val combineWithManyElements: Parser<(SequenceK<B>) -> SequenceK<B>> =
+            manySeparatedElements.map { a: SequenceK<B> -> { b: SequenceK<B> -> (a + b).k() } }
+
+        val result: Parser<SequenceK<B>> = elementAsSeq.ap(combineWithManyElements).fix()
+        val emptySequence: Parser<SequenceK<B>> = just(emptySequence<B>().k()).fix()
+        (result alt emptySequence).map { it.toList() }.fix()
+    }
+
+val jsonArray: Parser<JsonValue> =
+    ParserAlternativeInstance.run {
+        val separator = whiteSpace.followedBy(charParser(',')).apTap(whiteSpace).fix()
+        val elements: Parser<List<JsonValue>> = sepBy(separator, jsonValue())
+        val prefix = charParser('[').followedBy(whiteSpace)
+        val suffix = whiteSpace.apTap(charParser(']'))
+        val result: Parser<List<JsonValue>> = prefix.followedBy(elements).apTap(suffix).fix()
+        result.map { JsonArray(it) }
+    }
+
+val jsonObject: Parser<JsonValue> =
+    ParserAlternativeInstance.run {
+        val prefix = charParser('{').apTap(whiteSpace).fix()
+        val suffix = whiteSpace.followedBy(charParser('}')).fix()
+        val objectSeparator = whiteSpace.followedBy(charParser(',')).apTap(whiteSpace).fix()
+
+        val keyValueSeparator: Parser<Char> = whiteSpace.followedBy(charParser(':')).apTap(whiteSpace).fix()
+
+        val combineIntoJsonValue: Parser<(Char) -> (StringView) -> Tuple2<String, JsonValue>> =
+            jsonValue().map { value: JsonValue -> { separator: Char -> { key: StringView -> key.value toT value } } }
+
+        val pair: Parser<Tuple2<String, JsonValue>> = stringLiteral.ap(keyValueSeparator.ap(combineIntoJsonValue))
+
+        prefix.followedBy(sepBy(objectSeparator, pair)).apTap(suffix).fix()
+            .map { JsonObject(it.toMap()) }
+    }
+
+fun jsonValue(): Parser<JsonValue> =
+    Parser { input ->
+        ParserAlternativeInstance.run {
+            jsonNull alt jsonBool alt jsonNumber alt jsonString alt jsonArray alt jsonObject
+        }.fix().runParser(input)
+    }
 
 @ExperimentalTime
 fun main() {
-    val sampleJson = Parser::class.java.getResourceAsStream("/sample.json").readBytes().toString(Charsets.UTF_8)
-    val tsodingScheduleJson =
-        Parser::class.java.getResourceAsStream("/tsoding_schedule.json").readBytes().toString(Charsets.UTF_8)
-    val _180mbJson = Parser::class.java.getResourceAsStream("/citylots_no_floats_no_negatives.json").readBytes()
-        .toString(Charsets.UTF_8)
-    measureParse("""{"test": [[-1,[2],[1,2,3]], 1,2,3], "foo": 1, "bar": false, "baz": "value"}""")
-    jsonNumber().runParser(StringView.from("1-1"))
+    val sampleJson = loadResource("/sample.json")
+    val tsodingScheduleJson = loadResource("/tsoding_schedule.json")
+    val githubGists = loadResource("/github_gists.json")
+//    val _180mbJson = loadResource("/citylots_no_floats_no_negatives.json")
+    measureParse("""{"test": [[-1,[2],[[4,3,[9,8,7], 2], 1,2,3]], 1,2,3], "foo": 1, "bar": false, "baz": "value"}""")
     measureParse(sampleJson)
     measureParse(tsodingScheduleJson)
-    measureParse(_180mbJson)
+    measureParse(githubGists)
+//    measureParse(_180mbJson)
 }
+
+fun loadResource(name: String) = Parser::class.java.getResourceAsStream(name).readBytes().toString(Charsets.UTF_8)
 
 @ExperimentalTime
 fun measureParse(s: String) {
-    val f: TimedValue<Option<Tuple2<StringView, JsonValue>>> = measureTimedValue {
+    val f: TimedValue<Tuple2<StringView, JsonValue>?> = measureTimedValue {
         jsonValue().runParser(StringView.from(s))
     }
 
-    println("Took ${f.duration} to parse ${f.value.map { it.b }}")
+    println("Took ${f.duration} to parse ${f.value?.b}")
 }

--- a/src/main/kotlin/io/github/kartoffelsup/json/StringView.kt
+++ b/src/main/kotlin/io/github/kartoffelsup/json/StringView.kt
@@ -43,7 +43,7 @@ data class StringView private constructor(
 
     operator fun get(index: Int): Char = buffer[startIndex + index]
 
-    val value: String by lazy { if (isEmpty()) "" else buffer.substring(startIndex..endIndex) }
+    val value: String by lazy { if (isEmpty()) "" else buffer.substring(startIndex, endIndex + 1) }
 
     companion object {
         fun from(s: String) = StringView(s, 0, s.length - 1)

--- a/src/main/kotlin/io/github/kartoffelsup/json/typeclass.kt
+++ b/src/main/kotlin/io/github/kartoffelsup/json/typeclass.kt
@@ -1,7 +1,7 @@
 package io.github.kartoffelsup.json
 
 import arrow.Kind
-import arrow.core.AndThen
+import arrow.core.Eval
 import arrow.core.Tuple2
 import arrow.typeclasses.Alternative
 import arrow.typeclasses.Applicative
@@ -12,9 +12,7 @@ interface ParserFunctor : Functor<ForParser> {
 }
 
 interface ParserApplicative : Applicative<ForParser> {
-    override fun <A> just(a: A): Parser<A> = Parser(AndThen { input ->
-        Tuple2(input, a)
-    })
+    override fun <A> just(a: A): Parser<A> = Parser.just(a)
 
     override fun <A, B> ParserOf<A>.ap(ff: ParserOf<(A) -> B>): Parser<B> = fix().ap(ff)
 
@@ -22,7 +20,7 @@ interface ParserApplicative : Applicative<ForParser> {
 }
 
 interface ParserAlternative : Alternative<ForParser> {
-    override fun <A> empty(): Parser<A> = Parser { null }
+    override fun <A> empty(): Parser<A> = Parser { Eval.just(null) }
 
     override fun <A> just(a: A): ParserOf<A> = Parser.just(a)
 
@@ -30,9 +28,12 @@ interface ParserAlternative : Alternative<ForParser> {
 
     override fun <A, B> ParserOf<A>.lazyAp(ff: () -> ParserOf<(A) -> B>) = fix().lazyAp(ff)
 
-    override fun <A> Kind<ForParser, A>.orElse(b: Kind<ForParser, A>): Kind<ForParser, A> = Parser(
-        this.fix().runParser.flatMap { g -> b.fix().runParser.map { bo -> g ?: bo } }
-    )
+    override fun <A> Kind<ForParser, A>.orElse(b: Kind<ForParser, A>): Kind<ForParser, A> = Parser { input ->
+        this.fix().runParser(input).flatMap { tuple: Tuple2<StringView, A>? ->
+            if (tuple != null) Eval.just(tuple)
+            else b.fix().runParser(input)
+        }
+    }
 }
 
 object ParserFunctorInstance : ParserFunctor

--- a/src/test/kotlin/io/github/kartoffelsup/json/ParserLaws.kt
+++ b/src/test/kotlin/io/github/kartoffelsup/json/ParserLaws.kt
@@ -1,5 +1,6 @@
 package io.github.kartoffelsup.json
 
+import arrow.core.Eval
 import arrow.core.None
 import arrow.core.Option
 import arrow.core.Tuple2
@@ -15,8 +16,8 @@ import io.kotlintest.properties.Gen
 
 object ParserEqK : EqK<ForParser> {
     override fun <A> ParserOf<A>.eqK(other: ParserOf<A>, EQ: Eq<A>): Boolean {
-        val first: Tuple2<StringView, A>? = fix().runParser(StringView.from(""))
-        val second: Tuple2<StringView, A>? = other.fix().runParser(StringView.from(""))
+        val first: Tuple2<StringView, A>? = fix().runParser(StringView.from("")).value()
+        val second: Tuple2<StringView, A>? = other.fix().runParser(StringView.from("")).value()
         return Option.eqK().run {
             first == second
         }
@@ -27,7 +28,7 @@ class ParserLawsTest : UnitSpec() {
     init {
         val genK = object : GenK<ForParser> {
             override fun <A> genK(gen: Gen<A>): Gen<ParserOf<A>> {
-                return gen.orNull().map { a -> a?.let { Parser.just(it) } ?: Parser { null } }
+                return gen.orNull().map { a -> a?.let { Parser.just(it) } ?: Parser { Eval.just(null) } }
             }
         }
         testLaws(

--- a/src/test/kotlin/io/github/kartoffelsup/json/ParserLaws.kt
+++ b/src/test/kotlin/io/github/kartoffelsup/json/ParserLaws.kt
@@ -1,32 +1,39 @@
 package io.github.kartoffelsup.json
 
-import arrow.Kind
+import arrow.core.None
+import arrow.core.Option
+import arrow.core.Tuple2
+import arrow.core.extensions.option.eqK.eqK
 import arrow.test.UnitSpec
+import arrow.test.generators.GenK
 import arrow.test.laws.AlternativeLaws
 import arrow.test.laws.ApplicativeLaws
 import arrow.test.laws.FunctorLaws
 import arrow.typeclasses.Eq
+import arrow.typeclasses.EqK
+import io.kotlintest.properties.Gen
 
-interface ParserIntEq : Eq<Kind<ForParser, Int>> {
-    override fun Kind<ForParser, Int>.eqv(b: Kind<ForParser, Int>): Boolean {
-        return fix().runParser(StringView.from("asdf")) == b.fix().runParser(StringView.from("asdf")) &&
-                fix().runParser(StringView.from("")) == b.fix().runParser(StringView.from(""))
+object ParserEqK : EqK<ForParser> {
+    override fun <A> ParserOf<A>.eqK(other: ParserOf<A>, EQ: Eq<A>): Boolean {
+        val first: Tuple2<StringView, A>? = fix().runParser(StringView.from(""))
+        val second: Tuple2<StringView, A>? = other.fix().runParser(StringView.from(""))
+        return Option.eqK().run {
+            first == second
+        }
     }
 }
 
-object ParserIntEqInstance : ParserIntEq
-
 class ParserLawsTest : UnitSpec() {
     init {
+        val genK = object : GenK<ForParser> {
+            override fun <A> genK(gen: Gen<A>): Gen<ParserOf<A>> {
+                return gen.orNull().map { a -> a?.let { Parser.just(it) } ?: Parser { null } }
+            }
+        }
         testLaws(
-            FunctorLaws.laws(ParserFunctorInstance, { Parser.just(it) }, ParserIntEqInstance),
-            ApplicativeLaws.laws(ParserApplicativeInstance, ParserIntEqInstance),
-            AlternativeLaws.laws(
-                ParserAlternativeInstance,
-                { Parser.just(it) },
-                { i -> Parser.just { j: Int -> i + j } },
-                ParserIntEqInstance
-            )
+            FunctorLaws.laws(ParserFunctorInstance, genK, ParserEqK),
+            ApplicativeLaws.laws(ParserApplicativeInstance, genK, ParserEqK),
+            AlternativeLaws.laws(ParserAlternativeInstance, genK, ParserEqK)
         )
     }
 }

--- a/src/test/kotlin/io/github/kartoffelsup/json/ParserTest.kt
+++ b/src/test/kotlin/io/github/kartoffelsup/json/ParserTest.kt
@@ -1,7 +1,6 @@
 package io.github.kartoffelsup.json
 
 import arrow.core.None
-import arrow.core.Option
 import arrow.core.Some
 import arrow.core.Tuple2
 import arrow.core.toT
@@ -15,8 +14,8 @@ class ParserTest : StringSpec({
     "charParser" {
         assertAll(Gen.nonEmptyString()) { str: String ->
             val first: Char = str.first()
-            val parsedChar: Option<Tuple2<StringView, Char>> = charParser(first).runParser(StringView.from(str))
-            parsedChar.map { it.b } shouldBe Some(first)
+            val parsedChar: Tuple2<StringView, Char>? = charParser(first).runParser(StringView.from(str))
+            parsedChar?.b shouldBe first
         }
     }
 
@@ -25,65 +24,64 @@ class ParserTest : StringSpec({
             val first: Char = str.first()
             val second: Char? = str.drop(1).firstOrNull()
             val stringView = StringView.from(str)
-            val someMaybe: Option<Tuple2<StringView, Option<Char>>> = maybe(first).runParser(stringView)
-            someMaybe.map { it.b } shouldBe Some(Some(first))
+            val someMaybe: Tuple2<StringView, Char?>? = maybe(first).runParser(stringView)
+            someMaybe?.b shouldBe first
             if (second != null && first != second) {
                 val noneMaybe = maybe(second).runParser(stringView)
-                noneMaybe.map { it.b } shouldBe Some(None)
+                noneMaybe?.b shouldBe null
             }
         }
     }
 
     "spanParser" {
         assertAll(Gen.string(), CharPredicateGen) { str: String, predWrapper: CharPredicateWrapper ->
-            val parsedString: Option<Tuple2<StringView, StringView>> =
+            val parsedString: Tuple2<StringView, StringView>? =
                 spanParser(predWrapper.predicate).runParser(StringView.from(str))
             val expected: Tuple2<String, String> = str.span(predWrapper.predicate).reverse()
-            parsedString.map { it.a.value toT it.b.value } shouldBe Some(expected)
+            parsedString?.let { it.a.value toT it.b.value } shouldBe expected
         }
     }
 
     "stringParser" {
         assertAll { str: String ->
-            val parsedString: Option<Tuple2<StringView, String>> = stringParser(str).runParser(StringView.from(str))
-            parsedString.map { it.b } shouldBe Some(str)
+            val parsedString: Tuple2<StringView, String>? = stringParser(str).runParser(StringView.from(str))
+            parsedString?.b shouldBe str
         }
     }
 
     "jsonNull" {
-        val jsonNull = jsonNull().runParser(StringView.from("null"))
-        jsonNull.map { it.b } shouldBe Some(JsonNull)
+        val jsonNull = jsonNull.runParser(StringView.from("null"))
+        jsonNull?.b shouldBe JsonNull
     }
 
     "whitespace" {
-        val jsonNull = whiteSpace().runParser(StringView.from(" \n \r\n \r \t"))
-        jsonNull.map { it.a.value toT it.b.value } shouldBe Some(Tuple2("", " \n \r\n \r \t"))
+        val jsonNull = whiteSpace.runParser(StringView.from(" \n \r\n \r \t"))
+        jsonNull?.let { it.a.value toT it.b.value } shouldBe Tuple2("", " \n \r\n \r \t")
     }
 
     "jsonBool" {
-        val boolTrue = jsonBool().runParser(StringView.from("true"))
-        val boolFalse = jsonBool().runParser(StringView.from("false"))
-        val notABool = jsonBool().runParser(StringView.from("notABool"))
-        boolTrue.map { it.b } shouldBe Some(JsonBool(true))
-        boolFalse.map { it.b } shouldBe Some(JsonBool(false))
-        notABool.map { it.b } shouldBe None
+        val boolTrue = jsonBool.runParser(StringView.from("true"))
+        val boolFalse = jsonBool.runParser(StringView.from("false"))
+        val notABool = jsonBool.runParser(StringView.from("notABool"))
+        boolTrue?.b shouldBe JsonBool(true)
+        boolFalse?.b shouldBe JsonBool(false)
+        notABool?.b shouldBe null
     }
 
     "notEmpty" {
         assertAll { input: String ->
             val inputView = StringView.from(input)
-            val notEmpty: Option<Tuple2<StringView, StringView>> = notEmpty(spanParser { true }).runParser(inputView)
-            val actual: Option<StringView> = notEmpty.map { it.b }
-            val expected = if (input.isEmpty()) None else Some(inputView)
+            val notEmpty: Tuple2<StringView, StringView>? = notEmpty(spanParser { true }).runParser(inputView)
+            val actual: StringView? = notEmpty?.b
+            val expected = if (input.isEmpty()) null else inputView
             actual shouldBe expected
         }
     }
 
     "jsonNumber" {
         assertAll { number: Int ->
-            val jsonValue: Option<Tuple2<StringView, JsonValue>> =
-                jsonNumber().runParser(StringView.from(number.toString()))
-            jsonValue.map { it.b } shouldBe Some(JsonNumber(number))
+            val jsonValue: Tuple2<StringView, JsonValue>? = jsonNumber.runParser(StringView.from(number.toString()))
+            jsonValue?.b shouldBe JsonNumber(number)
         }
     }
 })

--- a/src/test/kotlin/io/github/kartoffelsup/json/ParserTest.kt
+++ b/src/test/kotlin/io/github/kartoffelsup/json/ParserTest.kt
@@ -14,7 +14,7 @@ class ParserTest : StringSpec({
     "charParser" {
         assertAll(Gen.nonEmptyString()) { str: String ->
             val first: Char = str.first()
-            val parsedChar: Tuple2<StringView, Char>? = charParser(first).runParser(StringView.from(str))
+            val parsedChar: Tuple2<StringView, Char>? = charParser(first).runParser(StringView.from(str)).value()
             parsedChar?.b shouldBe first
         }
     }
@@ -24,10 +24,10 @@ class ParserTest : StringSpec({
             val first: Char = str.first()
             val second: Char? = str.drop(1).firstOrNull()
             val stringView = StringView.from(str)
-            val someMaybe: Tuple2<StringView, Char?>? = maybe(first).runParser(stringView)
+            val someMaybe: Tuple2<StringView, Char?>? = maybe(first).runParser(stringView).value()
             someMaybe?.b shouldBe first
             if (second != null && first != second) {
-                val noneMaybe = maybe(second).runParser(stringView)
+                val noneMaybe = maybe(second).runParser(stringView).value()
                 noneMaybe?.b shouldBe null
             }
         }
@@ -36,7 +36,7 @@ class ParserTest : StringSpec({
     "spanParser" {
         assertAll(Gen.string(), CharPredicateGen) { str: String, predWrapper: CharPredicateWrapper ->
             val parsedString: Tuple2<StringView, StringView>? =
-                spanParser(predWrapper.predicate).runParser(StringView.from(str))
+                spanParser(predWrapper.predicate).runParser(StringView.from(str)).value()
             val expected: Tuple2<String, String> = str.span(predWrapper.predicate).reverse()
             parsedString?.let { it.a.value toT it.b.value } shouldBe expected
         }
@@ -44,25 +44,25 @@ class ParserTest : StringSpec({
 
     "stringParser" {
         assertAll { str: String ->
-            val parsedString: Tuple2<StringView, String>? = stringParser(str).runParser(StringView.from(str))
+            val parsedString: Tuple2<StringView, String>? = stringParser(str).runParser(StringView.from(str)).value()
             parsedString?.b shouldBe str
         }
     }
 
     "jsonNull" {
-        val jsonNull = jsonNull.runParser(StringView.from("null"))
+        val jsonNull = jsonNull.runParser(StringView.from("null")).value()
         jsonNull?.b shouldBe JsonNull
     }
 
     "whitespace" {
-        val jsonNull = whiteSpace.runParser(StringView.from(" \n \r\n \r \t"))
+        val jsonNull = whiteSpace.runParser(StringView.from(" \n \r\n \r \t")).value()
         jsonNull?.let { it.a.value toT it.b.value } shouldBe Tuple2("", " \n \r\n \r \t")
     }
 
     "jsonBool" {
-        val boolTrue = jsonBool.runParser(StringView.from("true"))
-        val boolFalse = jsonBool.runParser(StringView.from("false"))
-        val notABool = jsonBool.runParser(StringView.from("notABool"))
+        val boolTrue = jsonBool.runParser(StringView.from("true")).value()
+        val boolFalse = jsonBool.runParser(StringView.from("false")).value()
+        val notABool = jsonBool.runParser(StringView.from("notABool")).value()
         boolTrue?.b shouldBe JsonBool(true)
         boolFalse?.b shouldBe JsonBool(false)
         notABool?.b shouldBe null
@@ -71,7 +71,7 @@ class ParserTest : StringSpec({
     "notEmpty" {
         assertAll { input: String ->
             val inputView = StringView.from(input)
-            val notEmpty: Tuple2<StringView, StringView>? = notEmpty(spanParser { true }).runParser(inputView)
+            val notEmpty: Tuple2<StringView, StringView>? = notEmpty(spanParser { true }).runParser(inputView).value()
             val actual: StringView? = notEmpty?.b
             val expected = if (input.isEmpty()) null else inputView
             actual shouldBe expected
@@ -80,7 +80,7 @@ class ParserTest : StringSpec({
 
     "jsonNumber" {
         assertAll { number: Int ->
-            val jsonValue: Tuple2<StringView, JsonValue>? = jsonNumber.runParser(StringView.from(number.toString()))
+            val jsonValue: Tuple2<StringView, JsonValue>? = jsonNumber.runParser(StringView.from(number.toString())).value()
             jsonValue?.b shouldBe JsonNumber(number)
         }
     }

--- a/src/test/kotlin/io/github/kartoffelsup/json/StringViewTest.kt
+++ b/src/test/kotlin/io/github/kartoffelsup/json/StringViewTest.kt
@@ -8,7 +8,7 @@ import io.kotlintest.properties.assertAll
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.StringSpec
 
-class CharPredicateWrapper(val predicate: (Char) -> Boolean, val description: String) {
+class CharPredicateWrapper(val predicate: (Char) -> Boolean, private val description: String) {
     override fun toString(): String = description
 }
 
@@ -23,7 +23,7 @@ object CharPredicateGen : Gen<CharPredicateWrapper> {
             CharPredicateWrapper(Char::isLowerCase, "Char::isLowerCase"),
             CharPredicateWrapper({ a: Char -> a == 'a' }, "{ a: Char -> a == 'a' }"),
             CharPredicateWrapper({ a: Char -> a == 'b' }, "{ a: Char -> a == 'b' }"),
-            CharPredicateWrapper({ a: Char -> a == 'c' }, "{ a: Char -> a == 'c'}")
+            CharPredicateWrapper({ a: Char -> a == 'c' }, "{ a: Char -> a == 'c' }")
         )
     }
 


### PR DESCRIPTION
- Use Eval to Prevent StackOverFlows
  Albeit very slow (11mb json takes around 1.5 minutes to parse)
  The 100mb Citylots JSON didn't finish after 2 hours, but at least
  no StackOverFlows ;)

- Update to latest arrow snapshot
  Use left to right ap
  Get rid of manual `many` implementation
  Replaced Option with Nullable
